### PR TITLE
v 1.0.0 

### DIFF
--- a/scrolls/main.ttslua
+++ b/scrolls/main.ttslua
@@ -105,7 +105,7 @@ bonusScoringRetiredTranslators = function(params)
 
     For such Scroll Cards, the scoring is as follows:
     * 4 - 6 Retired Translators = 2 VP
-    * 7 Retired Translators = 4 VP
+    * 7+ Retired Translators = 4 VP
 
     Parameters
     ----------
@@ -120,7 +120,7 @@ bonusScoringRetiredTranslators = function(params)
     ]]
     -- PlayerEndState[params.player_color].retired_translators is an
     -- integer-indexed table containing the Player's Retired Translators
-    if #PlayerEndState[params.player_color].retired_translators == 7 then
+    if #PlayerEndState[params.player_color].retired_translators >= 7 then
         return 4
     elseif #PlayerEndState[params.player_color].retired_translators >= 4 then
         return 2


### PR DESCRIPTION
# Highlights

* Fixed the bonus scoring for retired translators to work for 7 or more

# Code

## scrolls

### main

* Fixed `bonusScoringRetiredTranslators` to work for 7 or more; was errantly checking for exactly 7
