### PR TITLE
Updating turnorder to not care about TTS-assigned player index

### DIFF
--- a/setup/Turn Order.ttslua
+++ b/setup/Turn Order.ttslua
@@ -47,8 +47,6 @@ function determinePlayerOrder()
     Turns.enable = true
     math.randomseed(os.time())
     local first_player = math.random(1, #Players)
-    broadcastToAll(Players[first_player] .. ' will be first player', Color[Players[first_player]])
-
     local order = reorderColors()
     -- Assume play proceeds clockwise around the existing hands from
     -- the assigned first player

--- a/setup/Turn Order.ttslua
+++ b/setup/Turn Order.ttslua
@@ -42,10 +42,10 @@ function determinePlayerOrder()
         Integer-indexed table of the string form of Player Colors.
 
     ]]
+    local Players = getSeatedPlayers()
     -- Determine where the players are sitting, and assign first player
     Turns.enable = true
     math.randomseed(os.time())
-    local Players = getSeatedPlayers()
     local first_player = math.random(1, #Players)
     broadcastToAll(Players[first_player] .. ' will be first player', Color[Players[first_player]])
 

--- a/setup/Turn Order.ttslua
+++ b/setup/Turn Order.ttslua
@@ -1,3 +1,34 @@
+function reorderColors()
+    local seated_players = getSeatedPlayers()
+    local new_order = {}
+    
+    for i=1,4 do
+        if seated_players[i] == "Red" then
+            new_order[#new_order+1] = seated_players[i]
+        end
+    end
+
+    for i=1,4 do
+        if seated_players[i] == "Teal" then
+            new_order[#new_order+1] = seated_players[i]
+        end
+    end
+
+    for i=1,4 do
+        if seated_players[i] == "Yellow" then
+            new_order[#new_order+1] = seated_players[i]
+        end
+    end
+
+    for i=1,4 do
+        if seated_players[i] == "Purple" then
+            new_order[#new_order+1] = seated_players[i]
+        end
+    end
+    return new_order
+end
+
+
 function determinePlayerOrder()
     --[[
     Determine the first player.
@@ -11,19 +42,19 @@ function determinePlayerOrder()
         Integer-indexed table of the string form of Player Colors.
 
     ]]
-    local Players = getSeatedPlayers()
     -- Determine where the players are sitting, and assign first player
     Turns.enable = true
     math.randomseed(os.time())
-    local first_player = math.random(1, #Players)
-    local order = {}
+    local seated_players = getSeatedPlayers()
+    local first_player_id = math.random(1, #seated_players)
+    broadcastToAll(seated_players[first_player_id] .. ' will be first player', Color[seated_players[first_player_id]])
+
+    local order = reorderColors()
     -- Assume play proceeds clockwise around the existing hands from
     -- the assigned first player
-    for i=1,#Players do
-        if first_player + i - 1 <= #Players then
-            order[i] = Players[first_player + i - 1]
-        else
-            order[i] = Players[first_player + i - 1 - #Players]
+    for i=1,#order do
+        if order[i] == seated_players[first_player_id] then
+            Wrap(order, #order - i + 1)
         end
     end
 

--- a/setup/Turn Order.ttslua
+++ b/setup/Turn Order.ttslua
@@ -45,15 +45,15 @@ function determinePlayerOrder()
     -- Determine where the players are sitting, and assign first player
     Turns.enable = true
     math.randomseed(os.time())
-    local seated_players = getSeatedPlayers()
-    local first_player_id = math.random(1, #seated_players)
-    broadcastToAll(seated_players[first_player_id] .. ' will be first player', Color[seated_players[first_player_id]])
+    local Players = getSeatedPlayers()
+    local first_player = math.random(1, #Players)
+    broadcastToAll(Players[first_player] .. ' will be first player', Color[Players[first_player]])
 
     local order = reorderColors()
     -- Assume play proceeds clockwise around the existing hands from
     -- the assigned first player
     for i=1,#order do
-        if order[i] == seated_players[first_player_id] then
+        if order[i] == Players[first_player] then
             Wrap(order, #order - i + 1)
         end
     end

--- a/utils/Extra Table Functions.ttslua
+++ b/utils/Extra Table Functions.ttslua
@@ -63,3 +63,11 @@ function sortDescending(t, sort_levels)
     )
 
 end
+
+function Wrap(t, l)
+    for i = 1, l do
+        table.insert( t, 1, t[#t] )
+        table.remove( t, #t )
+    end
+    return t
+end


### PR DESCRIPTION
When players join the TTS lobby, TTS gives them an index based on the order of joining in the getSeatedPlayers table.  Current turn order implementation uses this table, thus assuming that each person who joins the lobby picks the next color in clockwise order.
  
This update instead statically sets the turn-order table that we expect based on the color of seating in clockwise order, excluding non-seated players.  Then, after a first player is chosen at random, adjusts the order table by shifting the table down until the first player is the first index of the table.