### PR TITLE
v1.0.2 - Fix Turn Order

### DIFF
--- a/Global (Backup).ttslua
+++ b/Global (Backup).ttslua
@@ -1,6 +1,6 @@
 --[[
     Official Scholars Workshop ID: 2643607043
-    Version 1.0.1
+    Version 1.0.2
     Author:
         Steam: SJ-the-kiwi
     Contributor:

--- a/onLoad.ttslua
+++ b/onLoad.ttslua
@@ -9,10 +9,10 @@ function onLoad()
     -- MasterGoldCounter.setPosition(Vector(7, -1, 0))
 
     PlayerTable = {
-        "Teal",
         "Red",
+        "Teal",
+        "Yellow",
         "Purple",
-        "Yellow"
     }
 
     languages = {

--- a/setup/Turn Order.ttslua
+++ b/setup/Turn Order.ttslua
@@ -11,21 +11,19 @@ function determinePlayerOrder()
         Integer-indexed table of the string form of Player Colors.
 
     ]]
-    local Players = getSeatedPlayers()
     -- Determine where the players are sitting, and assign first player
-    Turns.enable = true
-    math.randomseed(os.time())
-    local first_player = math.random(1, #Players)
     local order = {}
-    -- Assume play proceeds clockwise around the existing hands from
-    -- the assigned first player
-    for i=1,#Players do
-        if first_player + i - 1 <= #Players then
-            order[i] = Players[first_player + i - 1]
-        else
-            order[i] = Players[first_player + i - 1 - #Players]
+    for _, color in ipairs(PlayerTable) do
+        if Player[color].seated then
+            table.insert(order, color)
         end
     end
+    Turns.enable = true
+    math.randomseed(os.time())
+    local first_player = math.random(1, #order)
+    -- Assume play proceeds clockwise around the existing hands from
+    -- the assigned first player
+    table.shift(order, first_player)
 
     printToAll('Turn order for the game will be:', log_message_color)
     for idx, player_color in ipairs(order) do

--- a/utils/Extra Table Functions.ttslua
+++ b/utils/Extra Table Functions.ttslua
@@ -63,3 +63,23 @@ function sortDescending(t, sort_levels)
     )
 
 end
+
+function table.shift(t, idx)
+    --[[
+    Given an array, shift the values from [idx, #t] to the front of t.
+
+    The shift will happen in place.
+
+    Parameters
+    ----------
+    t : table
+        Array containing the values to be shifted.
+    idx : int
+        The index where the shift should start.
+
+    ]]
+    for i=1, #t - (idx + 1) do
+        table.insert(t, 1, t[#t])
+        table.remove(t, #t)
+    end
+end

--- a/utils/Extra Table Functions.ttslua
+++ b/utils/Extra Table Functions.ttslua
@@ -78,7 +78,7 @@ function table.shift(t, idx)
         The index where the shift should start.
 
     ]]
-    for i=1, #t - (idx + 1) do
+    for i=1, (#t - idx) + 1 do
         table.insert(t, 1, t[#t])
         table.remove(t, #t)
     end


### PR DESCRIPTION
# Highlights

* Fixed a bug where the turn order for the game was affected by the order in which players joined the game

# Code

## onLoad

* Reordered `PlayerTable` to match the clockwise orientation of the seats in TTS

## setup

### Turn Order

* Fixed the turn order bug

## utils

### Extra Table Functions

* Added a new table method called `table.shift` that basically takes the slice `[idx:]` and moves it to the front of the supplied table